### PR TITLE
change instance type to t3.medium

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ You can either call modules by their Fully Qualified Collection Name (FQCN), suc
       state: present
       engine: mariadb
       storage_encrypted: True
-      db_instance_class: db.t2.medium
+      db_instance_class: db.t3.medium
       username: "{{ username }}"
       password: "{{ password }}"
       allocated_storage: "{{ allocated_storage }}"

--- a/plugins/modules/autoscaling_launch_config.py
+++ b/plugins/modules/autoscaling_launch_config.py
@@ -248,7 +248,7 @@ EXAMPLES = r'''
       name: lc1
       image_id: ami-xxxx
       assign_public_ip: true
-      instance_type: t2.medium
+      instance_type: t3.medium
       key_name: my-key
       security_groups: "['sg-xxxx']"
       volumes: "{{ volumes }}"


### PR DESCRIPTION
Dear team,
we want to get rid of all unsupported ec2-nitro instance types. I would kindly ask you to switch to at least t3.medium here. It should also be cheaper and faster than t2.medium.

In case of questions, feel free to contact me.

Thank you